### PR TITLE
added pagehandlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ Any options your want to pass into the [page.js](https://github.com/visionmedia/
 system can be done via `routeroptions`. The above example is using hashbang routing.
 Other options can be [found here](https://github.com/visionmedia/page.js#pageoptions)
 
+Also, setting pagehandlers directly is possible using the `pagehandlers` field in `routeroptions`.
+For example, to enable page transitions:
+
+      routeroptions.pagehandlers = {
+        '*': function(ctx, next) {
+          if (window.url !== ctx.canonicalPath) {
+            window.url = ctx.canonicalPath;
+            $('#content').addClass('fadeout').removeClass('fadein');
+            return setTimeout(function() {
+              $('#content').addClass('fadein').removeClass('fadeout');
+              window.loadingbar.go(100);
+              return next();
+            }, 400);
+          } else {
+            return next();
+          }
+        }
+      };
 
 ## About
 

--- a/lib/routehandler.js
+++ b/lib/routehandler.js
@@ -9,6 +9,8 @@ if (typeof require !== "undefined" && require !== null) {
   page = window.page;
 }
 
+this.page = page;
+
 this.on('mount', (function(_this) {
   return function() {
     var basepath, ref;

--- a/lib/routehandler.js
+++ b/lib/routehandler.js
@@ -13,6 +13,9 @@ this.on('mount', (function(_this) {
   return function() {
     var basepath, ref;
     _this.tagstack = [];
+    if( opts.routeroptions && opts.routeroptions.pagehandlers != undefined)
+      for( p in opts.routeroptions.pagehandlers ) 
+        page(p,opts.routeroptions.pagehandlers[p])
     if (opts.routes) {
       _this.mountRoutes({
         handler: _this

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-routehandler",
-  "version": "1.1.0",
+  "version": "1.1.01",
   "description": "A angular-ui-router inspired router handler for riot.js",
   "main": "lib/routehandler.js",
   "repository": "crisward/riot-routehandler",

--- a/src/routehandler.tag
+++ b/src/routehandler.tag
@@ -10,6 +10,9 @@ routehandler
       page = window.page
     @on 'mount',=>
       @tagstack = []
+      if opts.routeroptions and opts.routeroptions.pagehandlers?
+        for p of opts.routeroptions.pagehandlers
+          page p, opts.routeroptions.pagehandlers[p]
       if opts.routes
         @mountRoutes({handler:@},opts.routes)
         if opts.options?.base

--- a/src/routehandler.tag
+++ b/src/routehandler.tag
@@ -8,6 +8,9 @@ routehandler
       return console.log 'Page.js not found - please check it has been npm installed or included in your page'
     else
       page = window.page
+
+    @page = page
+
     @on 'mount',=>
       @tagstack = []
       if opts.routeroptions and opts.routeroptions.pagehandlers?


### PR DESCRIPTION
In order to achieve page transitions, I needed to talk directly to the page object, _before_ the `routes` were being set on the page object.
Anyways, I figured adding `pagehandlers` to the `routeroptions`-object might be a handy way to do raw page.js-stuff.
